### PR TITLE
Remove redundant file path steps

### DIFF
--- a/Calculator.html
+++ b/Calculator.html
@@ -2,31 +2,31 @@
 <html>
 	<head>
 		<title>Aoife Pearson</title>
-		<link rel="stylesheet" href="../Aoife//Content/style.css"/>
-    	<link href="../Aoife/Content/bootstrap.css" rel="stylesheet" />
-    	<link href="../Aoife/Content/SassMain.css" rel="stylesheet" />
+		<link rel="stylesheet" href="Content/style.css"/>
+    	<link href="Content/bootstrap.css" rel="stylesheet" />
+    	<link href="Content/SassMain.css" rel="stylesheet" />
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
-		<script src="../Aoife/Scripts/custom.js"></script>
+		<script src="Scripts/custom.js"></script>
 	</head>
 	<body>
 	 <nav class="navbar navbar-light bg-light">
         <span class="navbar-brand mb-0 h1">Aoife</span>
         <ul class="nav justify-content-end">
             <li class="nav-item">
-                <a class="nav-link active" href="../Aoife/Index.html">Home</a>
+                <a class="nav-link active" href="Index.html">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Gallery.html">Gallery</a>
+                <a class="nav-link" href="Gallery.html">Gallery</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Vikings.html">Vikings</a>
+                <a class="nav-link" href="Vikings.html">Vikings</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Calculator.html">Calculator</a>
+                <a class="nav-link" href="Calculator.html">Calculator</a>
 
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/trending.html">Giphy</a>
+                <a class="nav-link" href="trending.html">Giphy</a>
 
             </li>
         </ul>

--- a/Gallery.html
+++ b/Gallery.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8" />
     <title>Aoife Pearson</title>
-    <link href="../Aoife/Content/bootstrap.css" rel="stylesheet" />
-    <link href="../Aoife/Content/SassMain.css" rel="stylesheet" />
+    <link href="Content/bootstrap.css" rel="stylesheet" />
+    <link href="Content/SassMain.css" rel="stylesheet" />
 </head>
 <body>
     <!--navbar-->
@@ -12,19 +12,19 @@
         <span class="navbar-brand mb-0 h1">Aoife</span>
         <ul class="nav justify-content-end">
             <li class="nav-item">
-                <a class="nav-link active" href="../Aoife/Index.html">Home</a>
+                <a class="nav-link active" href="Index.html">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Gallery.html">Gallery</a>
+                <a class="nav-link" href="Gallery.html">Gallery</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Vikings.html">Vikings</a>
+                <a class="nav-link" href="Vikings.html">Vikings</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Calculator.html">Calculator</a>
+                <a class="nav-link" href="Calculator.html">Calculator</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/trending.html">Giphy</a>
+                <a class="nav-link" href="trending.html">Giphy</a>
             </li>
         </ul>
     </nav>  
@@ -40,46 +40,46 @@
         <div class="container gallery-grid mx-auto grid">
             <div class="row ">
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/DigitalPainting.jpg" alt="red haired lady" />
+                    <img src="IMG/DigitalPainting.jpg" alt="red haired lady" />
                 </div>
 
                 <div class="col-md-3 col-sm-12 grid-item text-center grid-middle">
-                    <img src="../Aoife/IMG/fish.jpg" alt="betta fish" />
+                    <img src="IMG/fish.jpg" alt="betta fish" />
                 </div>
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/fishlady.jpg" alt="water goddess" />
+                    <img src="IMG/fishlady.jpg" alt="water goddess" />
                 </div>
             </div>
             <div class="row">
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/hagrid.png" alt="hagrid" />
+                    <img src="IMG/hagrid.png" alt="hagrid" />
                 </div>
                 <div class="col-md-3 col-sm-12 grid-item text-center grid-middle">
-                    <img src="../Aoife/IMG/marybag.jpg" alt="Mary winchester bag" />
+                    <img src="IMG/marybag.jpg" alt="Mary winchester bag" />
                 </div>
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/raven.jpg" alt="raven goddess" />
+                    <img src="IMG/raven.jpg" alt="raven goddess" />
                 </div>
             </div>
             <div class="row">
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/skull.jpg" alt="skull drawing" />
+                    <img src="IMG/skull.jpg" alt="skull drawing" />
                 </div>
                 <div class="col-md-3 col-sm-12 grid-item text-center grid-middle">
-                    <img src="../Aoife/IMG/spyro.jpg" />
+                    <img src="IMG/spyro.jpg" />
                 </div>
                 <div class="col-md-3 col-sm-12 grid-item text-center">
-                    <img src="../Aoife/IMG/yellow mushroom.jpg" />
+                    <img src="IMG/yellow mushroom.jpg" />
                 </div>
             </div>
             <div class="row">
                 <div class="col-12">
-                    <a href="../Aoife/Index.html"><button class="btn btn-light btn-gallery">Return to Home Page</button></a>
+                    <a href="Index.html"><button class="btn btn-light btn-gallery">Return to Home Page</button></a>
                 </div>
             </div>
         </div>
     </div>
-    <script src="../Aoife/Scripts/jquery-3.0.0.js"></script>
-    <script src="../Aoife/Scripts/bootstrap.js"></script>
+    <script src="Scripts/jquery-3.0.0.js"></script>
+    <script src="Scripts/bootstrap.js"></script>
 </body>
 </html>

--- a/Vikings.html
+++ b/Vikings.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8" />
     <title>Aoife Pearson</title>
-    <link href="../Aoife/Content/bootstrap.css" rel="stylesheet" />
-    <link href="../Aoife/Content/SassMain.css" rel="stylesheet" />
+    <link href="Content/bootstrap.css" rel="stylesheet" />
+    <link href="Content/SassMain.css" rel="stylesheet" />
 </head>
 <body>
     <!--navbar-->
@@ -12,20 +12,20 @@
         <span class="navbar-brand mb-0 h1">Aoife</span>
         <ul class="nav justify-content-end">
             <li class="nav-item">
-                <a class="nav-link active" href="../Aoife/Index.html">Home</a>
+                <a class="nav-link active" href="Index.html">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Gallery.html">Gallery</a>
+                <a class="nav-link" href="Gallery.html">Gallery</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Vikings.html">Vikings</a>
+                <a class="nav-link" href="Vikings.html">Vikings</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Calculator.html">Calculator</a>
+                <a class="nav-link" href="Calculator.html">Calculator</a>
 
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/trending.html">Giphy</a>
+                <a class="nav-link" href="trending.html">Giphy</a>
 
             </li>
         </ul>
@@ -67,13 +67,13 @@
     <div class="container mx-auto">
         <div class="row mx-auto">
             <div class="col-md-4 col-sm-12 text-center viking-img" id="viking-img">
-                <img src="../Aoife/IMG/viking2.jpg" alt="shield wall" />
+                <img src="IMG/viking2.jpg" alt="shield wall" />
             </div>
             <div class="col-md-4 col-sm-12 text-center viking-img" id="viking-img">
-                <img src="../Aoife/IMG/viking1.jpg" alt="me in my viking kit" />
+                <img src="IMG/viking1.jpg" alt="me in my viking kit" />
             </div>
             <div class="col-md-3 col-sm-12 text-center viking-img" id="viking-img">
-                <img src="../Aoife/IMG/Viking.jpg" alt="night battle" />
+                <img src="IMG/Viking.jpg" alt="night battle" />
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8" />
     <title>Aoife Pearson</title>
-    <link href="../Aoife/Content/bootstrap.css" rel="stylesheet" />
-    <link href="../Aoife/Content/SassMain.css" rel="stylesheet" />
+    <link href="Content/bootstrap.css" rel="stylesheet" />
+    <link href="Content/SassMain.css" rel="stylesheet" />
 </head>
 <body>
     <!--navbar-->
@@ -13,20 +13,20 @@
         <span class="navbar-brand mb-0 h1">Aoife</span>
         <ul class="nav justify-content-end">
             <li class="nav-item">
-                <a class="nav-link active" href="../Aoife/Index.html">Home</a>
+                <a class="nav-link active" href="Index.html">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Gallery.html">Gallery</a>
+                <a class="nav-link" href="Gallery.html">Gallery</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Vikings.html">Vikings</a>
+                <a class="nav-link" href="Vikings.html">Vikings</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Calculator.html">Calculator</a>
+                <a class="nav-link" href="Calculator.html">Calculator</a>
 
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/trending.html">Giphy</a>
+                <a class="nav-link" href="trending.html">Giphy</a>
 
             </li>
         </ul>
@@ -42,7 +42,7 @@
         <div class="row">
             <div class="col-md-12 about mx-auto">
                 <div class="rounded-circle mx-auto">
-                    <img class="modal-dialog-centered" src="../Aoife/IMG/Aoife.jpg" alt="Image of Aoife" />
+                    <img class="modal-dialog-centered" src="IMG/Aoife.jpg" alt="Image of Aoife" />
                 </div>
             </div>
         </div>
@@ -57,21 +57,21 @@
         </ol>
         <div class="carousel-inner">
             <div class="carousel-item item active">
-                <img class="d-block w-100 bigImg" src="../Aoife/IMG/coding.jpeg" alt="Web Design">
+                <img class="d-block w-100 bigImg" src="IMG/coding.jpeg" alt="Web Design">
                 <div class="carousel-caption d-none d-md-block">
                     <h5>Web Design</h5>
                     <p>I have a passion for web design and enjoy using HTML,CSS with JQuery</p>
                 </div>
             </div>
             <div class="carousel-item item">
-                <img class="d-block w-100" src="../Aoife/IMG/design.png" alt="Software Development">
+                <img class="d-block w-100" src="IMG/design.png" alt="Software Development">
                 <div class="carousel-caption d-none d-md-block">
                     <h5>Software Development</h5>
                     <p>I have experience using C# and Angular JS which I love using to create functional web solutions</p>
                 </div>
             </div>
             <div class="carousel-item item">
-                <img class="d-block w-100" src="../Aoife/IMG/software-testing.jpg" alt="QA Quality Assurance">
+                <img class="d-block w-100" src="IMG/software-testing.jpg" alt="QA Quality Assurance">
                 <div class="carousel-caption d-none d-md-block">
                     <h5>QA</h5>
                     <p>I have worked in QA as a tester and used tools such as Test Manager and BrowserStack for end to end testing</p>
@@ -132,25 +132,25 @@
         <div class="col-md-5 half mx-auto">
             <h4 class="text-center">Digital Painting</h4>
 
-            <img class="halfimg text-center" src="../Aoife/IMG/DigitalPainting.jpg" alt="Digital Painting" />
+            <img class="halfimg text-center" src="IMG/DigitalPainting.jpg" alt="Digital Painting" />
 
             <h5 class="text-center">In my spare time I am a digital painter and independant artist, I like to use Photoshop and a Wacom tablet to hand-draw artwork straight into digital. My absolute favourite theme to work on is fantasy </h5>
-            <a href="../Aoife/Gallery.html"><button class="btn btn-light">Go To Gallery</button></a>
+            <a href="Gallery.html"><button class="btn btn-light">Go To Gallery</button></a>
         </div>
         <div class="col-md-5 half mx-auto">
             <h4 class="text-center">Viking Reenactment</h4>
 
-            <img class="halfimg text-center" src="../Aoife/IMG/Viking.jpg" alt="Viking Reenactment" />
+            <img class="halfimg text-center" src="IMG/Viking.jpg" alt="Viking Reenactment" />
 
             <h5 class="text-center">Twice a week I train as a reenactor at Scrampage, I will also travel for shows around the country (and hopefully around the globe one day) to compete in show fights as a Danish Mercenary and become part of living history </h5>
-            <a href="../Aoife/Vikings.html"><button class="btn btn-light">Go To Vikings</button></a>
+            <a href="Vikings.html"><button class="btn btn-light">Go To Vikings</button></a>
         </div>
     </div>
 
 
 
 
-    <script src="../Aoife/Scripts/jquery-3.0.0.js"></script>
-    <script src="../Aoife/Scripts/bootstrap.js"></script>
+    <script src="Scripts/jquery-3.0.0.js"></script>
+    <script src="Scripts/bootstrap.js"></script>
 </body>
 </html>

--- a/trending.html
+++ b/trending.html
@@ -2,29 +2,29 @@
 <html>
 <head>
 	<title>Aoife Pearson</title>
-    	<link href="../Aoife/Content/bootstrap.css" rel="stylesheet" />
-    	<link href="../Aoife/Content/SassMain.css" rel="stylesheet" />
+    	<link href="Content/bootstrap.css" rel="stylesheet" />
+    	<link href="Content/SassMain.css" rel="stylesheet" />
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
-		<script src="../Aoife/Scripts/giphy.js"></script>
+		<script src="Scripts/giphy.js"></script>
 </head>
 <body>
 	 <nav class="navbar navbar-light bg-light">
         <span class="navbar-brand mb-0 h1">Aoife</span>
         <ul class="nav justify-content-end">
             <li class="nav-item">
-                <a class="nav-link active" href="../Aoife/Index.html">Home</a>
+                <a class="nav-link active" href="Index.html">Home</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Gallery.html">Gallery</a>
+                <a class="nav-link" href="Gallery.html">Gallery</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Vikings.html">Vikings</a>
+                <a class="nav-link" href="Vikings.html">Vikings</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/Calculator.html">Calculator</a>
+                <a class="nav-link" href="Calculator.html">Calculator</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="../Aoife/trending.html">Giphy</a>
+                <a class="nav-link" href="trending.html">Giphy</a>
             </li>
         </ul>
     </nav>	


### PR DESCRIPTION
Hey Aoife, I revisited your Github page/website, and found there was a problem with the way you formatted your file paths. 

"../foo" in a file path, means go 'out/back/up' one directory, and then go into the 'foo' directory. 

You used "../Aoife/foo" throughout your repo, which will work so long as the root directory is called 'Aoife'. That might be true on your local machine (and hence your website might be working fine locally), but on github pages, the root directory will be called 'APDigital.github.io', since that's the name of the repo. 

Besides that problem, there's no need to go 'up' a directory, if you are then just stepping back into the same one you left, which I think is what was happening in all such cases. 

So I've removed all those extra steps, which also solves the 'Aoife' vs 'APDigital.github.io' problem.

This change, should therefore make the website work both locally, and up on github pages. 

There are no merge conflicts (currently) so feel free to merge this pull request to get the fix right away